### PR TITLE
test: add tests for hasAnnotationSelector functionality

### DIFF
--- a/pkg/diff/filter_test.go
+++ b/pkg/diff/filter_test.go
@@ -278,53 +278,53 @@ func TestFilterResources_AnnotationSelector(t *testing.T) {
 	objects := []*unstructured.Unstructured{frontendObj, backendObj, stagingObj, noAnnotationsObj}
 
 	tests := []struct {
-		name                string
-		annotationSelector  map[string]string
-		expectedCount       int
-		expectedNames       []string
-		notExpectedNames    []string
+		name               string
+		annotationSelector map[string]string
+		expectedCount      int
+		expectedNames      []string
+		notExpectedNames   []string
 	}{
 		{
-			name:                "managed-by helm selector",
-			annotationSelector:  map[string]string{"app.kubernetes.io/managed-by": "helm"},
-			expectedCount:       2,
-			expectedNames:       []string{"frontend-app", "staging-config"},
-			notExpectedNames:    []string{"backend-app", "secret"},
+			name:               "managed-by helm selector",
+			annotationSelector: map[string]string{"app.kubernetes.io/managed-by": "helm"},
+			expectedCount:      2,
+			expectedNames:      []string{"frontend-app", "staging-config"},
+			notExpectedNames:   []string{"backend-app", "secret"},
 		},
 		{
-			name:                "multiple annotation selectors (AND logic)",
-			annotationSelector:  map[string]string{"app.kubernetes.io/managed-by": "helm", "environment": "production"},
-			expectedCount:       1,
-			expectedNames:       []string{"frontend-app"},
-			notExpectedNames:    []string{"backend-app", "staging-config", "secret"},
+			name:               "multiple annotation selectors (AND logic)",
+			annotationSelector: map[string]string{"app.kubernetes.io/managed-by": "helm", "environment": "production"},
+			expectedCount:      1,
+			expectedNames:      []string{"frontend-app"},
+			notExpectedNames:   []string{"backend-app", "staging-config", "secret"},
 		},
 		{
-			name:                "environment production selector",
-			annotationSelector:  map[string]string{"environment": "production"},
-			expectedCount:       2,
-			expectedNames:       []string{"frontend-app", "backend-app"},
-			notExpectedNames:    []string{"staging-config", "secret"},
+			name:               "environment production selector",
+			annotationSelector: map[string]string{"environment": "production"},
+			expectedCount:      2,
+			expectedNames:      []string{"frontend-app", "backend-app"},
+			notExpectedNames:   []string{"staging-config", "secret"},
 		},
 		{
-			name:                "deployment category web selector",
-			annotationSelector:  map[string]string{"deployment.category": "web"},
-			expectedCount:       1,
-			expectedNames:       []string{"frontend-app"},
-			notExpectedNames:    []string{"backend-app", "staging-config", "secret"},
+			name:               "deployment category web selector",
+			annotationSelector: map[string]string{"deployment.category": "web"},
+			expectedCount:      1,
+			expectedNames:      []string{"frontend-app"},
+			notExpectedNames:   []string{"backend-app", "staging-config", "secret"},
 		},
 		{
-			name:                "empty selector returns all objects",
-			annotationSelector:  nil,
-			expectedCount:       4,
-			expectedNames:       []string{"frontend-app", "backend-app", "staging-config", "secret"},
-			notExpectedNames:    []string{},
+			name:               "empty selector returns all objects",
+			annotationSelector: nil,
+			expectedCount:      4,
+			expectedNames:      []string{"frontend-app", "backend-app", "staging-config", "secret"},
+			notExpectedNames:   []string{},
 		},
 		{
-			name:                "non-matching selector returns empty",
-			annotationSelector:  map[string]string{"nonexistent": "value"},
-			expectedCount:       0,
-			expectedNames:       []string{},
-			notExpectedNames:    []string{"frontend-app", "backend-app", "staging-config", "secret"},
+			name:               "non-matching selector returns empty",
+			annotationSelector: map[string]string{"nonexistent": "value"},
+			expectedCount:      0,
+			expectedNames:      []string{},
+			notExpectedNames:   []string{"frontend-app", "backend-app", "staging-config", "secret"},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for `hasAnnotationSelector` functionality in `FilterResources`
- Add tests for combined `LabelSelector` and `AnnotationSelector` filtering with AND logic

## Changes
- **TestFilterResources_AnnotationSelector**: Tests annotation selector filtering with various scenarios:
  - Single annotation selectors (managed-by, deployment.category, etc.)
  - Multiple annotation selectors (AND logic)
  - Empty selectors
  - Non-matching selectors
  - Objects without annotations

- **TestFilterResources_CombinedLabelAndAnnotationSelector**: Tests combined filtering:
  - Both label and annotation match (AND condition)
  - Label matches but annotation doesn't
  - Annotation matches but label doesn't
  - Multiple selectors for both labels and annotations
  - Only label selector or only annotation selector

## Test Coverage
All tests verify that:
- The correct number of objects are filtered
- Expected objects are included in results
- Unexpected objects are excluded from results
- AND logic works correctly when both selectors are specified

## Test Results
```
=== RUN   TestFilterResources_AnnotationSelector
--- PASS: TestFilterResources_AnnotationSelector (0.00s)
=== RUN   TestFilterResources_CombinedLabelAndAnnotationSelector  
--- PASS: TestFilterResources_CombinedLabelAndAnnotationSelector (0.00s)
```

All tests pass successfully, confirming the implementation works as expected.